### PR TITLE
Allow to create split migrations for same version.

### DIFF
--- a/migrations_server.js
+++ b/migrations_server.js
@@ -176,8 +176,16 @@ Migrations._migrateTo = function(version, rerun) {
     return;
   }
 
-  var startIdx = this._findIndexByVersion(currentVersion);
-  var endIdx = this._findIndexByVersion(version);
+  var startIdx = this._findMigrationsByVersion(currentVersion);
+  var endIdx = this._findMigrationsByVersion(version);
+
+  if(currentVersion < version){
+    startIdx = startIdx[startIdx.length-1];
+    endIdx = endIdx[endIdx.length-1];
+  }else{
+    startIdx = startIdx[startIdx.length-1];
+    endIdx = endIdx[0];
+  }
 
   // log.info('startIdx:' + startIdx + ' endIdx:' + endIdx);
   log.info('Migrating from version ' + this._list[startIdx].version
@@ -253,14 +261,18 @@ Migrations._setControl = function(control) {
   return control;
 }
 
-// returns the migration index in _list or throws if not found
-Migrations._findIndexByVersion = function(version) {
+// returns the migrations indexs in _list or throws if not found
+Migrations._findMigrationsByVersion = function(version) {
+  var migrationIndex = [];
   for (var i = 0;i < this._list.length;i++) {
     if (this._list[i].version === version)
-      return i;
+      migrationIndex.push(i);
   }
 
-  throw new Meteor.Error('Can\'t find migration version ' + version);
+  if(migrationIndex.length === 0)
+    throw new Meteor.Error('Can\'t find migration version ' + version);
+
+  return migrationIndex.sort();
 }
 
 //reset (mainly intended for tests)

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Define and run db migrations.",
-  version: "0.9.6",
+  version: "0.9.7",
   name: "percolate:migrations",
   git: "https://github.com/percolatestudio/meteor-migrations.git"
 });


### PR DESCRIPTION
Hi.

Looking for SRP I've changed your package to be able to create two or more migrations for the same version:

``` javascript
Migrations.add({up: function () {run.push('u1-2');}, version: 1});
Migrations.add({up: function () {run.push('u1-1');}, version: 1});
```

With this you can create migration packages for each service/model that have to be modified.
